### PR TITLE
Removing Ask.com from pinged Search Engines

### DIFF
--- a/lib/sitemap/ping.rb
+++ b/lib/sitemap/ping.rb
@@ -7,7 +7,6 @@ module Sitemap
 
     SEARCH_ENGINES = {
       "Google"  => "http://www.google.com/webmasters/tools/ping?sitemap=%s",
-      "Ask.com" => "http://submissions.ask.com/ping?sitemap=%s",
       "Bing"    => "http://www.bing.com/webmaster/ping.aspx?siteMap=%s",
       "Yandex"    => "http://webmaster.yandex.ru/wmconsole/sitemap_list.xml?host=%s"
     }


### PR DESCRIPTION
Removing Ask.com from pinged SearchEngines. They no longer use this method and it was causing an error when running "rake sitemap:ping"

The error I was getting in Ubuntu 12.04 was the following:

```
rake aborted!
getaddrinfo: Name or service not known

Tasks: TOP => sitemap:ping
(See full trace by running task with --trace)
```

More info here:
http://webmasters.stackexchange.com/questions/31057/ask-com-sitemap-crawler-down-for-good
