### PR TITLE
Adding context to file_url...

### DIFF
--- a/lib/sitemap/generator.rb
+++ b/lib/sitemap/generator.rb
@@ -10,7 +10,7 @@ module Sitemap
       :priority         => "priority"
     }
 
-    attr_accessor :store, :protocol, :host, :routes, :fragments
+    attr_accessor :store, :protocol, :host, :routes, :fragments, :context
 
     # Instantiates a new object.
     # Should never be called directly.
@@ -186,7 +186,13 @@ module Sitemap
     #
     # Defaults to <tt>sitemap.xml</tt>.
     def file_url(path = "sitemap.xml")
-      URI::HTTP.build(:host => host, :path => File.join("/", path)).to_s
+      if context
+        file_path = File.join("/", context, path)
+      else
+        file_path = File.join("/", path)
+      end
+
+      URI::HTTP.build(:host => host, :path => file_path).to_s
     end
 
     def remove_saved_files(location)

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -189,6 +189,11 @@ describe "Generator" do
     Sitemap::Generator.instance.file_url.must_equal "http://someplace.com/sitemap.xml"
   end
 
+  it "should set the sitemap url based on the current host and context" do
+    Sitemap::Generator.instance.load(:host => "someplace.com", :context => "foo/bar") {}
+    Sitemap::Generator.instance.file_url.must_equal "http://someplace.com/foo/bar/sitemap.xml"
+  end
+
   it "should create a file when saving" do
     path = File.join(Dir.tmpdir, "sitemap.xml")
     File.unlink(path) if File.exist?(path)


### PR DESCRIPTION
...such that a user can additionally specify contexts to the path where the .xml should be saved, outside of the assigned host.

In some situations, we might want the sitemap.xml and sitemaps/sitemap-fragments-*.xml to live elsewhere in our file tree.  The addition of :context upon load Sitemap::Generator.instance.load( :host => "www.somewhere.com", :context => "else/where" ) allows the /sitemaps directory and the sitemap.xml file to live elsewhere.  This also allows for S3 implementation where a developer might house the sitemap.xml and /sitemaps directory on S3.  Sitemap::Generator.instance.load( :host => "s3.amazonaws.com", :context => "some_bucket" ) so long that the real domain :host is passed when defining a literal '/some/path/here', :host => "www.mydomain.com") in the Sitemap::Generator.instance.load { ... } do block.
