### PR TITLE
Extend to add some resource sync elements to the sitemap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Sitemap::Generator.instance.load :host => "mywebsite.com" do
   literal "/my_blog" #helpful for vanity urls layering search results
   resources :activities, :params => { :format => "html" }
   resources :articles, :objects => proc { Article.published }
+  # example of added ResourceSync metadata elements
+  literal "/files/6t053f96k" metadata: { hash: "md5:1584abdf8ebdc9802ac0c6a7402c03b6", length: "8876", type: "text/html" }
 end
 ```
 

--- a/lib/sitemap/configuration.rb
+++ b/lib/sitemap/configuration.rb
@@ -6,6 +6,8 @@ module Sitemap
 
       PARAMS = {}.freeze
 
+      METADATA = {}.freeze
+
       SEARCH = {
         :updated_at => proc { |obj|
           obj.updated_at.strftime("%Y-%m-%d") if obj.respond_to?(:updated_at)
@@ -27,6 +29,7 @@ module Sitemap
     def reset
       self.data = {
         :params           => Defaults::PARAMS.dup,
+        :metadata         => Defaults::METADATA.dup,
         :search           => Defaults::SEARCH.dup,
         :query_batch_size => Defaults::QUERY_BATCH_SIZE,
         :max_urls         => Defaults::MAX_URLS
@@ -37,12 +40,16 @@ module Sitemap
       data[:params]
     end
 
+    def metadata
+      data[:metadata]
+    end
+
     def search
       data[:search]
     end
 
     def method_missing(method, *args, &block)
-      if /^(?<prefix>search|params)?_?(?<name>[a-z\_]+)(?<setter>=)?/ =~ method
+      if /^(?<prefix>search|params|metadata)?_?(?<name>[a-z\_]+)(?<setter>=)?/ =~ method
         if prefix
           if setter
             self.data[prefix.to_sym][name.to_sym] = args.first

--- a/lib/sitemap/generator.rb
+++ b/lib/sitemap/generator.rb
@@ -68,6 +68,7 @@ module Sitemap
     # Adds the literal url (for consistency, starting with a "/"  as in "/my_url")
     # accepts similar options to path and resources
     def literal(target_url, options = {})
+      metadata = Sitemap.configuration.params.clone.merge!(options[:metadata] || {})
       search = Sitemap.configuration.search.clone.merge!(options.select { |k, v| SEARCH_ATTRIBUTES.keys.include?(k) })
       search.merge!(search) { |type, value| get_data(nil, value) }
 
@@ -75,7 +76,8 @@ module Sitemap
       output_protocol = options[:protocol] || protocol
       self.store << {
         :url =>"#{output_protocol}://#{output_host}#{target_url}",
-        :search => search
+        :search => search,
+        :metadata => metadata
       }
     end
 

--- a/lib/sitemap/generator.rb
+++ b/lib/sitemap/generator.rb
@@ -69,6 +69,7 @@ module Sitemap
     # accepts similar options to path and resources
     def literal(target_url, options = {})
       metadata = Sitemap.configuration.params.clone.merge!(options[:metadata] || {})
+      link = Sitemap.configuration.params.clone.merge!(options[:link] || {})
       search = Sitemap.configuration.search.clone.merge!(options.select { |k, v| SEARCH_ATTRIBUTES.keys.include?(k) })
       search.merge!(search) { |type, value| get_data(nil, value) }
 
@@ -77,7 +78,8 @@ module Sitemap
       self.store << {
         :url =>"#{output_protocol}://#{output_host}#{target_url}",
         :search => search,
-        :metadata => metadata
+        :metadata => metadata,
+        :link => link
       }
     end
 

--- a/lib/views/fragment.xml.builder
+++ b/lib/views/fragment.xml.builder
@@ -1,5 +1,6 @@
 xml.instruct!
-xml.urlset :xmlns => "http://www.sitemaps.org/schemas/sitemap/0.9" do
+xml.urlset :xmlns => "http://www.sitemaps.org/schemas/sitemap/0.9", 'xmlns:rs' => 'http://www.openarchives.org/rs/terms/' do
+  xml.tag!('rs:md', { :capability => 'resourcelist', :at => Time.now.iso8601 })
 
   store.entries.each do |entry|
     xml.url do
@@ -7,6 +8,9 @@ xml.urlset :xmlns => "http://www.sitemaps.org/schemas/sitemap/0.9" do
       entry[:search].each do |type, value|
         next if !value || value.blank?
         xml.tag! SEARCH_ATTRIBUTES[type], value.to_s
+      end
+      unless entry[:metadata].nil?
+        xml.tag!('rs:md', entry[:metadata])
       end
     end
   end

--- a/lib/views/fragment.xml.builder
+++ b/lib/views/fragment.xml.builder
@@ -12,6 +12,9 @@ xml.urlset :xmlns => "http://www.sitemaps.org/schemas/sitemap/0.9", 'xmlns:rs' =
       unless entry[:metadata].nil?
         xml.tag!('rs:md', entry[:metadata])
       end
+      unless entry[:link].nil?
+        xml.tag!('rs:ln', entry[:link])
+      end
     end
   end
 

--- a/sitemap.gemspec
+++ b/sitemap.gemspec
@@ -14,6 +14,7 @@ spec = Gem::Specification.new do |spec|
   spec.add_development_dependency "nokogiri"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "rails", ">= 3.0.0"
+  spec.add_development_dependency "byebug"
 
   spec.files = Dir["{lib,docs}/**/*"] + ["README.md", "LICENSE", "Rakefile", "sitemap.gemspec"]
   spec.test_files = Dir["test/**/*"]

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -1,4 +1,5 @@
 require "minitest/autorun"
+require 'byebug'
 require File.expand_path("../minitest_helper", __FILE__)
 
 describe "Generator" do
@@ -32,6 +33,20 @@ describe "Generator" do
     elements.length.must_equal urls.length
     elements.each_with_index do |element, i|
       element.text.must_equal urls[i]
+    end
+  end
+
+  it "should create entries based on literals with hash" do
+    metadata = { hash: "md5:1584abdf8ebdc9802ac0c6a7402c03b6", length: "8876", type: "text/html" } 
+    Sitemap::Generator.instance.load(:host => "someplace.com") do
+      literal "/target_url", metadata: { hash: "md5:1584abdf8ebdc9802ac0c6a7402c03b6", length: "8876", type: "text/html" } 
+    end
+    Sitemap::Generator.instance.build!
+    doc = Nokogiri::HTML(Sitemap::Generator.instance.render)
+    element = doc.at_xpath "//url/md"
+    element.keys.length.must_equal metadata.length
+    element.keys.each_with_index do |attribute, i|
+      element[attribute].must_equal metadata[attribute.to_sym]
     end
   end
 
@@ -197,7 +212,7 @@ describe "Generator" do
   it "should create a file when saving" do
     path = File.join(Dir.tmpdir, "sitemap.xml")
     File.unlink(path) if File.exist?(path)
-    Sitemap::Generator.instance.load(:host => "someplace.com") do
+    Sitemap::Generator.instance.load(host: "someplace.com") do
       resources :activities
     end
     Sitemap::Generator.instance.build!
@@ -215,7 +230,7 @@ describe "Generator" do
     end
 
     it "should save files" do
-      Sitemap::Generator.instance.load(:host => "someplace.com") do
+      Sitemap::Generator.instance.load(host: "someplace.com") do
         path :root
         path :root
         path :root
@@ -233,7 +248,7 @@ describe "Generator" do
     end
 
     it "should have an index page" do
-      Sitemap::Generator.instance.load(:host => "someplace.com") do
+      Sitemap::Generator.instance.load(host: "someplace.com") do
         path :root
         path :root
         path :root
@@ -241,8 +256,8 @@ describe "Generator" do
         path :root
       end
       Sitemap::Generator.instance.build!
-      doc = Nokogiri::HTML(Sitemap::Generator.instance.render("index"))
-      elements = doc.xpath "//sitemap"
+      doc = Nokogiri::HTML(Sitemap::Generator.instance.render('index'))
+      elements = doc.xpath '//sitemap'
       Sitemap::Generator.instance.fragments.length.must_equal 3
     end
 

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -50,6 +50,21 @@ describe "Generator" do
     end
   end
 
+  it "should create entries based on literals with link" do
+    link = { href: "/content_url", rel: "contents" }
+    Sitemap::Generator.instance.load(:host => "someplace.com") do
+      literal "/target_url", link: { href: "/content_url", rel: "contents" }
+    end
+    Sitemap::Generator.instance.build!
+    doc = Nokogiri::HTML(Sitemap::Generator.instance.render)
+    element = doc.at_xpath "//url/ln"
+    element.keys.length.must_equal link.length
+    element.keys.each_with_index do |attribute, i|
+      element[attribute].must_equal link[attribute.to_sym]
+    end
+
+  end
+
   it "should create entries based on literals with https" do
     urls = ["https://someplace.com/target_url", "https://someplace.com/another_url"]
     Sitemap::Generator.instance.load(:host => "someplace.com", :protocol => "https") do


### PR DESCRIPTION
http://www.openarchives.org/rs/1.0/resourcesync defines some metadata elements that agregators or harvesters of your sitemap might find useful. This is in part based on work that @mjgiarlo started.

I'm looking for feedback on my approach and if this meets the needs of anyone else. If so it can hopefully be merged upstream.
